### PR TITLE
Added covers to books and refactored the OpenLibraryClient

### DIFF
--- a/backend/src/main/java/com/poglibrary/backend/control/BookEventHandler.java
+++ b/backend/src/main/java/com/poglibrary/backend/control/BookEventHandler.java
@@ -52,15 +52,16 @@ public class BookEventHandler {
          *    -> add the field and refactor openLibraryClient
          */
         if (book.getAuthors() == null || book.getTitle() == null) {
+            //OpenLibraryClient client = new OpenLibraryClient(isbnFormatted);
             OpenLibraryClient client = new OpenLibraryClient(isbnFormatted);
 
             if (book.getTitle() == null) {
-                book.setTitle(client.getTitle());
+                book.setTitle(client.getEdition().getTitle());
             }
 
             if (book.getAuthors() == null) {
                 Set<Author> authors = new HashSet<Author>();
-                for (String clientAuthor : client.getAuthors()) {
+                for (String clientAuthor : client.getEdition().getAuthorNames()) {
                     Author newAuthor = new Author(clientAuthor);
 
                     Set<Author> existingAuthors = authorRepository
@@ -79,7 +80,9 @@ public class BookEventHandler {
             }
 
             if (book.coverRequested()) {
-                byte[] coverBytes = client.getCover();
+                // for now just use the very first image that is found
+                // also check for null-safety
+                byte[] coverBytes = client.getEdition().getCoverImagesImages()[0];
                 Cover cover = new Cover(coverBytes);
                 coverRepository.save(cover);
 

--- a/backend/src/main/java/com/poglibrary/backend/control/FetchBookInfo/NewOpenLibraryClient.java
+++ b/backend/src/main/java/com/poglibrary/backend/control/FetchBookInfo/NewOpenLibraryClient.java
@@ -1,4 +1,0 @@
-package com.poglibrary.backend.control.FetchBookInfo;
-
-public class NewOpenLibraryClient {
-}

--- a/backend/src/main/java/com/poglibrary/backend/control/FetchBookInfo/NewOpenLibraryClient.java
+++ b/backend/src/main/java/com/poglibrary/backend/control/FetchBookInfo/NewOpenLibraryClient.java
@@ -1,0 +1,4 @@
+package com.poglibrary.backend.control.FetchBookInfo;
+
+public class NewOpenLibraryClient {
+}

--- a/backend/src/main/java/com/poglibrary/backend/control/FetchBookInfo/OpenLibraryTypes/Author.java
+++ b/backend/src/main/java/com/poglibrary/backend/control/FetchBookInfo/OpenLibraryTypes/Author.java
@@ -1,0 +1,19 @@
+package com.poglibrary.backend.control.FetchBookInfo.OpenLibraryTypes;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Author {
+    // for endpoint /authors via AuthorId
+    String key;
+    String name;
+}

--- a/backend/src/main/java/com/poglibrary/backend/control/FetchBookInfo/OpenLibraryTypes/Cover.java
+++ b/backend/src/main/java/com/poglibrary/backend/control/FetchBookInfo/OpenLibraryTypes/Cover.java
@@ -1,0 +1,18 @@
+package com.poglibrary.backend.control.FetchBookInfo.OpenLibraryTypes;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Cover {
+    Integer key;
+    byte[] image;
+}

--- a/backend/src/main/java/com/poglibrary/backend/control/FetchBookInfo/OpenLibraryTypes/Edition.java
+++ b/backend/src/main/java/com/poglibrary/backend/control/FetchBookInfo/OpenLibraryTypes/Edition.java
@@ -1,0 +1,42 @@
+package com.poglibrary.backend.control.FetchBookInfo.OpenLibraryTypes;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Arrays;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Edition {
+    // for endpoint /books via BookId or /isbn via isbn
+    String title;
+    Author[] authors;
+    String[] publishers;
+    String[] isbn_10;
+    String[] isbn_13;
+    String full_title;
+    String subtitle;
+    Integer[] covers; // in this context only as intermediate storage
+    Cover[] coverImages;
+    String key;
+
+    public String[] getAuthorNames() {
+        return Arrays.stream(this.authors)
+                .map(Author::getName)
+                .toArray(String[]::new);
+    }
+
+    public byte[][] getCoverImagesImages() {
+        return Arrays.stream(this.coverImages)
+                .map(Cover::getImage)
+                .toArray(byte[][]::new);
+    }
+}
+

--- a/backend/src/main/java/com/poglibrary/backend/model/Book.java
+++ b/backend/src/main/java/com/poglibrary/backend/model/Book.java
@@ -9,9 +9,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -21,7 +23,10 @@ import lombok.Setter;
 @NoArgsConstructor
 @Entity
 public class Book {
-
+    /*
+     * ToDo:
+     *  - GET on the entity ( /books/1 ) does not use the BookProjection
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
@@ -33,8 +38,16 @@ public class Book {
     @Column(name = "title")
     private String title;
 
+    @Column(name = "coverRequested")
+    private Boolean coverRequested = false;
+
+    @OneToOne
+    @JoinColumn(name = "coverId")
+    private Cover cover;
+
     @ManyToMany(targetEntity = com.poglibrary.backend.model.Author.class, fetch = FetchType.EAGER)
-    @JoinTable(name = "author_book", joinColumns = @JoinColumn(name = "bookId"), inverseJoinColumns = @JoinColumn(name = "authorId"))
+    @JoinTable(name = "author_book", joinColumns = @JoinColumn(name = "bookId"),
+            inverseJoinColumns = @JoinColumn(name = "authorId"))
     private Set<Author> authors;
 
     @ManyToOne
@@ -47,6 +60,8 @@ public class Book {
         this.authors = authors;
         this.borrower = null;
     }
+
+    public Boolean coverRequested() { return this.coverRequested; }
 
     @Override
     public String toString() {

--- a/backend/src/main/java/com/poglibrary/backend/model/Cover.java
+++ b/backend/src/main/java/com/poglibrary/backend/model/Cover.java
@@ -1,0 +1,35 @@
+package com.poglibrary.backend.model;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.OneToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+public class Cover {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private long id;
+
+    @Lob
+    @Column(name = "coverImage", length = 20_000_000)
+    private byte[] coverImage;
+
+    @OneToOne(mappedBy = "cover")
+    private Book book;
+
+    public Cover(byte[] bytes) {
+        this.coverImage = bytes;
+    }
+}

--- a/backend/src/main/java/com/poglibrary/backend/model/projection/BookProjection.java
+++ b/backend/src/main/java/com/poglibrary/backend/model/projection/BookProjection.java
@@ -7,6 +7,7 @@ import org.springframework.data.rest.core.config.Projection;
 import com.poglibrary.backend.model.Author;
 import com.poglibrary.backend.model.Book;
 import com.poglibrary.backend.model.Borrower;
+import com.poglibrary.backend.model.Cover;
 
 
 @Projection(name = "bookProjection", types = { Book.class })
@@ -20,4 +21,6 @@ public interface BookProjection {
     Set<Author> getAuthors();
 
     Borrower getBorrower();
+
+    Cover getCover();
 }

--- a/backend/src/main/java/com/poglibrary/backend/repository/CoverRepository.java
+++ b/backend/src/main/java/com/poglibrary/backend/repository/CoverRepository.java
@@ -1,0 +1,10 @@
+package com.poglibrary.backend.repository;
+
+import com.poglibrary.backend.model.Cover;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource(collectionResourceRel = "covers", path = "covers")
+public interface CoverRepository extends CrudRepository<Cover, Long> {
+}

--- a/backend/src/test/java/com/poglibrary/backend/DbConnApplicationTests.java
+++ b/backend/src/test/java/com/poglibrary/backend/DbConnApplicationTests.java
@@ -1,13 +1,26 @@
 package com.poglibrary.backend;
 
+import com.poglibrary.backend.control.FetchBookInfo.OpenLibraryClient;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
 
 @SpringBootTest
 class DbConnApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+	//@Test
+	void TryOutStuff() {
+		try {
+			OpenLibraryClient client = new OpenLibraryClient("9783453317178");
+			System.out.println(client.getEdition().toString());
+		} catch (IOException | URISyntaxException ex){
+			ex.getCause();
+		}
+
+    }
 
 }


### PR DESCRIPTION
The `/books` API now has a boolean field `"coverRequested"` that, if true automatically retreives the books cover and returns it as byte-stream. In the process of writing this, the OpenLibraryClient has also been refactored to use Jackson for deserialization of the OpenLibrary API.